### PR TITLE
meshopt_simplifySloppy: Adds locked_vertices parameter

### DIFF
--- a/src/meshoptimizer.h
+++ b/src/meshoptimizer.h
@@ -282,7 +282,8 @@ MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_simplify(unsigned int* destination, co
  */
 MESHOPTIMIZER_EXPERIMENTAL size_t meshopt_simplifySloppy(unsigned int* destination, const unsigned int* indices, size_t index_count, 
   float* vertex_positions, float* vertex_normals, float* vertex_uvs,
-  size_t vertex_count, size_t vertex_positions_stride, size_t vertex_normals_stride, size_t vertex_uvs_stride, size_t target_index_count, const unsigned int* uv_islands);
+  size_t vertex_count, size_t vertex_positions_stride, size_t vertex_normals_stride, size_t vertex_uvs_stride, size_t target_index_count, const unsigned int* uv_islands, 
+  const bool* locked_vertices);
 
 /**
  * Experimental: Point cloud simplifier


### PR DESCRIPTION
* Can now provide an array of bools marking vertices as locked or not.
* Locked vertices will not be decimated.
* Useful for decimating sub-meshes with joins that you want to maintain with another sub-mesh.